### PR TITLE
Add ability to add and download check notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "vue": "^2.6.11"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^4.1.2",
-    "@vue/cli-plugin-eslint": "^4.1.2",
-    "@vue/cli-plugin-unit-jest": "^4.1.2",
-    "@vue/cli-service": "^4.1.2",
+    "@vue/cli-plugin-babel": "^4.2.2",
+    "@vue/cli-plugin-eslint": "^4.2.2",
+    "@vue/cli-plugin-unit-jest": "^4.2.2",
+    "@vue/cli-service": "^4.2.2",
     "@vue/eslint-config-standard": "^4.0.0",
     "@vue/test-utils": "1.0.0-beta.29",
     "alpheios-client-adapters": "github:alpheios-project/client-adapters",
@@ -29,6 +29,7 @@
     "eslint-plugin-vue": "^5.0.0",
     "sass": "^1.25.0",
     "sass-loader": "^8.0.2",
+    "uuid": "^3.4.0",
     "vue-template-compiler": "^2.6.11"
   },
   "eslintConfig": {

--- a/src/components/check-homonym/check-homonym.vue
+++ b/src/components/check-homonym/check-homonym.vue
@@ -4,8 +4,9 @@
       <get-word-form
         @receive="receiveHomonym"  @changeGetShortDefinitions = "changeGetShortDefinitions"
         :wordListFromFile = "wordListFromFile"/>
+      <download-form :feedbackData="feedbackData" @clearFeedbackData="clearFeedbackData" />
       <div class="homonym-block" v-for="(homonymData, homonymID) of homonyms" v-bind:key="homonymID">
-        <homonym-data :homonym="homonymData.homonym" :views="homonymData.paradigmViews" :id="homonymID + 1" :showDefinitions="showDefinitions" />
+        <homonym-data :homonym="homonymData.homonym" :views="homonymData.paradigmViews" :id="homonymID + 1" :showDefinitions="showDefinitions" @saveFeedback="saveFeedback"/>
       </div>
   </div>
 </template>
@@ -13,6 +14,7 @@
 import UploadWordsForm from '@/components/check-homonym/upload-words-form.vue'
 import GetWordForm from '@/components/check-homonym/get-word-form.vue'
 import HomonymData from '@/components/check-homonym/homonym-data.vue'
+import DownloadForm from '@/components/check-homonym/download-form.vue'
 
 import GetHomonymData from '@/services/get-homonym-data.js'
 
@@ -21,7 +23,8 @@ export default {
   components: {
     UploadWordsForm,
     GetWordForm,
-    HomonymData
+    HomonymData,
+    DownloadForm
   },
   data () {
     return {
@@ -29,7 +32,9 @@ export default {
       homonym: null,
       paradigmViews: null,
       homonyms: [],
-      showDefinitions: false
+      showDefinitions: false,
+      feedbackData: [],
+      separator: ';'
     }
   },
   computed: {
@@ -57,6 +62,22 @@ export default {
     },
     changeGetShortDefinitions (getShortDefinitions) {
       this.showDefinitions = getShortDefinitions
+    },
+
+    saveFeedback (dopInfo, label, value) {
+      this.feedbackData.push({
+        label,
+        value,
+        targetWord: dopInfo.targetWord ? dopInfo.targetWord : '',
+        lexID: dopInfo.lexID ? dopInfo.lexID : '',
+        lemma: dopInfo.lemma ? dopInfo.lemma : '',
+        inflFeatures: dopInfo.inflFeatures ? dopInfo.inflFeatures : '',
+        paradigmTableTitle: dopInfo.paradigmTableTitle ? dopInfo.paradigmTableTitle : ''
+      })
+    },
+
+    clearFeedbackData () {
+      this.feedbackData = []
     }
   }
 }

--- a/src/components/check-homonym/download-form.vue
+++ b/src/components/check-homonym/download-form.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="download-feedback">
+      <h2 :class="{ download_feedback_disabled: feedbackData.length === 0 }">Download Check Paradigms Notes</h2>
+      <div class="download-feedback-block">
+        <button class="download-feedback-button" @click="downloadList" :disabled="feedbackData.length === 0">Download notes</button>
+        <span class="download-feedback-clear" @click="clearFeedbackData" :disabled="feedbackData.length === 0">Clear notes</span>
+      </div>
+  </div>
+</template>
+<script>
+import Download from '@/services/download.js'
+
+export default {
+  name: 'DownloadForm',
+  components: {
+  },
+  props: {
+    feedbackData: Array
+  },
+  data () {
+    return {
+    }
+  },
+  methods: {
+    downloadList () {
+      let source = this.feedbackData
+      source.sort((a, b) => (a.targetWord > b.targetWord) ? 1 : ((b.targetWord > a.targetWord) ? -1 : 0))
+
+      const exportFields = [ 'targetWord', 'lexID', 'lemma', 'inflFeatures', 'paradigmTableTitle', 'label', 'value' ]
+      const result = Download.collectionToCSV(';', exportFields)(source)
+      Download.downloadBlob(result, `check-paradigms.csv`)
+    },
+    clearFeedbackData () {
+      this.$emit('clearFeedbackData')
+    }
+  }
+}
+</script>
+<style  lang="scss">
+  .download_feedback_disabled {
+      opacity: 50%;
+  }
+  .download-feedback-button {
+    font-weight: bold;
+    color: #fff;
+    cursor: pointer;
+    display: inline-block;
+    padding: 5px 15px;
+    vertical-align: middle;
+    border: 1px solid #c64906;
+    border-radius: 5px;
+    background: #c64906;
+    font-size: 14px;
+    outline: none;
+
+    &:disabled {
+        opacity: 50%;
+    }
+  }
+
+  .download-feedback-clear {
+    margin-left: 50px;
+    font-weight: bold;
+    color: #c64906;
+    cursor: pointer;
+    display: inline-block;
+    padding: 5px 15px;
+    vertical-align: middle;
+    border: 1px solid #c64906;
+    border-radius: 5px;
+    background: #eee;
+    font-size: 14px;
+    outline: none;
+
+    &:disabled {
+        opacity: 50%;
+    }
+  }
+</style>

--- a/src/components/check-homonym/feedback-item.vue
+++ b/src/components/check-homonym/feedback-item.vue
@@ -1,0 +1,61 @@
+<template>
+  <span class="feedback-items">
+    <span class="feedback-item feedback-item-checkbox" v-if="typeValue === 'checkbox'">
+        <input type="checkbox" :id="checkboxName" v-model="checkboxValue" @change="changeCheckbox">
+        <label :for="checkboxName">{{ label }}</label>
+    </span>
+    <span class="feedback-item feedback-item-input" v-if="typeValue === 'text'">
+        <label :for="inputName">{{ label }}</label>
+        <input type="text" :id="inputName" v-model="textValue" @change="changeInput" @key.enter="changeInput">
+    </span>
+  </span>
+</template>
+<script>
+import uuidv4 from 'uuid/v4'
+
+export default {
+  name: 'FeedbackItem',
+  components: {
+  },
+  props: {
+    label: String,
+    typeValue: String,
+    dopInfo: Object
+  },
+  data () {
+    return {
+      checkboxValue: false,
+      textValue: ''
+    }
+  },
+  computed: {
+    checkboxName () {
+      const id = uuidv4()
+      return 'checkbox-' + id
+    },
+    inputName () {
+      const id = uuidv4()
+      return 'input-' + id
+    }
+  },
+  methods: {
+    changeCheckbox () {
+      this.$emit('saveFeedback', this.dopInfo, this.label, this.checkboxValue)
+    },
+    changeInput () {
+      this.$emit('saveFeedback', this.dopInfo, this.label, this.textValue)
+    }
+  }
+}
+</script>
+<style  lang="scss">
+    .feedback-item {
+        display: inline-block;
+        padding-left: 50px;
+        color: #c64906;
+
+        label {
+            padding: 0 5px;
+        }
+    }
+</style>

--- a/src/components/check-homonym/homonym-data.vue
+++ b/src/components/check-homonym/homonym-data.vue
@@ -1,21 +1,27 @@
 <template>
     <div class="homonym-data-block" v-if="homonym">
-        <div class="target-word" @click="toggleShowDetails"><b>{{ id }}.</b> <b>Target word</b> - {{ homonym.targetWord }} ({{ homonym.language }}) <i class="arrow" :class="showClass"></i></div>
+        <p class="target-word">
+          <span @click="toggleShowDetails"><b>{{ id }}.</b> <b>Target word</b> - {{ homonym.targetWord }} ({{ homonym.language }}) <i class="arrow" :class="showClass"></i></span>
+          <feedback-item type-value="text" :dopInfo="createTargetWordDopInfo()" label="missing lemmas:" @saveFeedback="saveFeedback" />
+          <feedback-item type-value="text" :dopInfo="createTargetWordDopInfo()" label="missing tables:" @saveFeedback="saveFeedback" />
+        </p>
         <div class="homonym-data-block-details" v-show="showDetails" >
-            <lexemes-data :homonym="homonym" v-if="homonym" :showDefinitions="showDefinitions" />
-            <paradigm-tables-data :views="views" />
+            <lexemes-data :homonym="homonym" v-if="homonym" :showDefinitions="showDefinitions" @saveFeedback="saveFeedback"/>
+            <paradigm-tables-data :views="views" @saveFeedback="saveFeedback"/>
         </div>
     </div>
 </template>
 <script>
 import LexemesData from '@/components/check-homonym/lexemes-data.vue'
 import ParadigmTablesData from '@/components/check-homonym/paradigm-tables-data.vue'
+import FeedbackItem from '@/components/check-homonym/feedback-item.vue'
 
 export default {
   name: 'CheckHomonym',
   components: {
     LexemesData,
-    ParadigmTablesData
+    ParadigmTablesData,
+    FeedbackItem
   },
   props: {
     homonym: Object,
@@ -34,15 +40,26 @@ export default {
         'hidden': !this.showDetails,
         'shown': this.showDetails
       }
+    },
+    targetWord () {
+      return this.homonym ? this.homonym.targetWord : ''
     }
   },
   methods: {
     toggleShowDetails () {
       this.showDetails = !this.showDetails
+    },
+    createTargetWordDopInfo () {
+      return {
+        targetWord: this.targetWord
+      }
+    },
+    saveFeedback (dopInfo, label, value) {
+      dopInfo.targetWord = this.targetWord
+      this.$emit('saveFeedback', dopInfo, label, value)
     }
   }
 }
-
 </script>
 <style  lang="scss">
     .target-word {

--- a/src/components/check-homonym/paradigm-table.vue
+++ b/src/components/check-homonym/paradigm-table.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="paradigm-tables-data" v-if="table">
-      <div class="view-title" @click="toggleShowDetails"><span v-html="title"></span> <i class="arrow" :class="showClass"></i></div>
+      <div class="view-title" >
+        <span @click="toggleShowDetails"><span v-html="title"></span> <i class="arrow" :class="showClass"></i></span>
+        <feedback-item type-value="checkbox" :dop-info = "dopInfo" label="wrong table" @saveFeedback="saveFeedback" />
+      </div>
       <div class="infl-prdgm-tbl" v-show="showDetails">
         <div class="infl-prdgm-tbl__row" v-for="(row, rowID) in table.rows" v-bind:key="rowID">
           <div :class="cellClasses(cell)" class="infl-prdgm-tbl__cell" v-for="(cell, cellID) in row.cells" v-bind:key="cellID">
@@ -11,10 +14,12 @@
     </div>
 </template>
 <script>
+import FeedbackItem from '@/components/check-homonym/feedback-item.vue'
 
 export default {
   name: 'ParadigmTable',
   components: {
+    FeedbackItem
   },
   props: {
     table: Object,
@@ -31,6 +36,11 @@ export default {
         'hidden': !this.showDetails,
         'shown': this.showDetails
       }
+    },
+    dopInfo () {
+      return {
+        paradigmTableTitle: this.title.replace('<b>', '').replace('</b>', '')
+      }
     }
   },
   methods: {
@@ -43,6 +53,9 @@ export default {
     },
     toggleShowDetails () {
       this.showDetails = !this.showDetails
+    },
+    saveFeedback (dopInfo, label, value) {
+      this.$emit('saveFeedback', dopInfo, label, value)
     }
   }
 }

--- a/src/components/check-homonym/paradigm-tables-data.vue
+++ b/src/components/check-homonym/paradigm-tables-data.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="paradigm-tables-data" v-if="views && views.length > 0">
         <div class="paradigm-tables-data-item" v-for="(view, viewID) of views" v-bind:key="viewID" >
-            <paradigm-table :table="view.wideTable" :title="getTitle(view)"/>
+            <paradigm-table :table="view.wideTable" :title="getTitle(view)" @saveFeedback="saveFeedback"/>
         </div>
     </div>
 </template>
@@ -25,6 +25,9 @@ export default {
   methods: {
     getTitle (view) {
       return '<b>' + view.paradigm.paradigmID + '</b> - ' + view.title
+    },
+    saveFeedback (dopInfo, label, value) {
+      this.$emit('saveFeedback', dopInfo, label, value)
     }
   }
 }

--- a/src/services/download.js
+++ b/src/services/download.js
@@ -1,0 +1,25 @@
+export default class Download {
+  static collectionToCSV (delimiter, keys = []) {
+    return (collection = []) => {
+      const headers = keys.map(key => `${key}`).join(delimiter)
+      const extractKeyValues = record => keys.map(key => `${record[key]}`).join(delimiter)
+
+      return collection.reduce((csv, record) => {
+        return (`${csv}\n${extractKeyValues(record)}`).trim()
+      }, headers)
+    }
+  }
+
+  static downloadBlob (data, filename) {
+    const blob = new Blob([data], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+
+    a.href = url
+    a.download = filename || 'download'
+    document.getElementById('app').appendChild(a)
+    a.click()
+    a.remove()
+    return true
+  }
+}


### PR DESCRIPTION
For the issue https://github.com/alpheios-project/inflection-tables/issues/355
(updated here for easier check - http://alpheios-infl-check.irina-sklyarova.ru/)

Would look like this way:
![image](https://user-images.githubusercontent.com/12377640/74151241-73fc4600-4c57-11ea-92ea-910ae07a0c19.png)

result (csv)
```
targetWord;lexID;lemma;inflFeatures;paradigmTableTitle;label;value
δείκνῠται;;;;;missing tables:;hfss
ἔδοτον;;;;verbpdgm38 - δίδωμι: Aorist System Active;wrong table;true
ἔδοτον;1;δίδωμι;1. verb, dual, aorist, active, indicative, 2nd, omi_aor;;missing cell match;true
ἔδοτον;;;;;missing tables:;hhh
```
